### PR TITLE
Add Swagger UI configuration for authenticated API testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Foodify Server
+
+## Swagger / OpenAPI Playground
+
+This project now exposes interactive API documentation powered by [Swagger UI](https://swagger.io/tools/swagger-ui/) through Springdoc OpenAPI.
+
+### How to run locally
+1. Install dependencies and start the application:
+   ```bash
+   ./gradlew bootRun
+   ```
+2. Once the server is running, open your browser at [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html).
+
+### Authenticating requests in Swagger UI
+Many endpoints require a JWT access token. You can obtain a token by calling one of the authentication endpoints (for example `POST /api/auth/login`) with valid credentials. After retrieving the `accessToken` from the response:
+
+1. Open the Swagger UI page and press the **Authorize** button in the top-right corner.
+2. Select the `bearerAuth` scheme and enter the token in the field using the format:
+   ```
+   Bearer <your-jwt-token>
+   ```
+3. Click **Authorize** and then **Close**. All subsequent requests sent from Swagger UI will include the JWT in the `Authorization` header, allowing you to exercise protected endpoints.
+
+### Notes
+- The OpenAPI specification is available at `/v3/api-docs` (JSON) or `/v3/api-docs.yaml` (YAML).
+- Swagger UI and the OpenAPI documents are publicly accessible while the rest of the API remains protected by the existing security configuration.

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	implementation 'org.springframework.kafka:spring-kafka:3.1.1'

--- a/src/main/java/com/foodify/server/config/OpenApiConfig.java
+++ b/src/main/java/com/foodify/server/config/OpenApiConfig.java
@@ -1,0 +1,34 @@
+package com.foodify.server.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI foodifyOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Foodify API")
+                        .description("Interactive API documentation for the Foodify platform.")
+                        .version("v1"))
+                .components(new Components().addSecuritySchemes(SECURITY_SCHEME_NAME, buildSecurityScheme()))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
+    }
+
+    private SecurityScheme buildSecurityScheme() {
+        return new SecurityScheme()
+                .name(SECURITY_SCHEME_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+    }
+}

--- a/src/main/java/com/foodify/server/modules/auth/security/SecurityConfig.java
+++ b/src/main/java/com/foodify/server/modules/auth/security/SecurityConfig.java
@@ -36,10 +36,20 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf().disable()
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/oauth2/**", "/api/client/**", "/ws/**","/api/**", "/api/driver/*"  ,       // 👈 very important for SockJS
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/oauth2/**",
+                                "/api/client/**",
+                                "/ws/**",
+                                "/api/**",
+                                "/api/driver/*",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
                                 "/topic/**",      // 👈 allow pub/sub topics
                                 "/app/**",        // 👈 app-bound messages
-                                "/ws"     ).permitAll()
+                                "/ws"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## Summary
- add Springdoc OpenAPI dependency and Swagger UI configuration with a global JWT bearer security scheme
- allow access to OpenAPI and Swagger endpoints through the security configuration
- document how to launch Swagger UI and authenticate requests in a new README

## Testing
- ./gradlew test --console=plain *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ddd244dfac832c8c0106e7526ba9fa