### PR TITLE
Defer phone login tokens until verification

### DIFF
--- a/src/main/java/com/foodify/server/modules/auth/dto/phone/PhoneSignupStateResponse.java
+++ b/src/main/java/com/foodify/server/modules/auth/dto/phone/PhoneSignupStateResponse.java
@@ -23,4 +23,8 @@ public class PhoneSignupStateResponse {
     String email;
     String firstName;
     String lastName;
+    boolean loginAttempt;
+    String accessToken;
+    String refreshToken;
+    AuthenticatedClientResponse user;
 }


### PR DESCRIPTION
## Summary
- ensure phone login attempts only return verification state during signup start
- issue access and refresh tokens for existing clients after verification succeeds
- flag login attempts automatically for active sessions without exposing tokens prematurely

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68de3e7c76f0832c9691688d5b0bec2d