### PR TITLE
Add saved address management module

### DIFF
--- a/src/main/java/com/foodify/server/modules/addresses/api/SavedAddressController.java
+++ b/src/main/java/com/foodify/server/modules/addresses/api/SavedAddressController.java
@@ -1,0 +1,57 @@
+package com.foodify.server.modules.addresses.api;
+
+import com.foodify.server.modules.addresses.application.SavedAddressService;
+import com.foodify.server.modules.addresses.dto.SaveAddressRequest;
+import com.foodify.server.modules.addresses.dto.SavedAddressResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/addresses")
+@RequiredArgsConstructor
+public class SavedAddressController {
+
+    private final SavedAddressService savedAddressService;
+
+    @PreAuthorize("hasAuthority('ROLE_CLIENT')")
+    @PostMapping
+    public ResponseEntity<SavedAddressResponse> createAddress(@Valid @RequestBody SaveAddressRequest request,
+                                                              Authentication authentication) {
+        Long userId = extractUserId(authentication);
+        SavedAddressResponse response = savedAddressService.createAddress(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PreAuthorize("hasAuthority('ROLE_CLIENT')")
+    @PutMapping("/{addressId}")
+    public ResponseEntity<SavedAddressResponse> updateAddress(@PathVariable UUID addressId,
+                                                              @Valid @RequestBody SaveAddressRequest request,
+                                                              Authentication authentication) {
+        Long userId = extractUserId(authentication);
+        SavedAddressResponse response = savedAddressService.updateAddress(userId, addressId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PreAuthorize("hasAuthority('ROLE_CLIENT')")
+    @GetMapping("/mySavedAddresses")
+    public ResponseEntity<List<SavedAddressResponse>> getMySavedAddresses(Authentication authentication) {
+        Long userId = extractUserId(authentication);
+        List<SavedAddressResponse> addresses = savedAddressService.getAddressesForUser(userId);
+        return ResponseEntity.ok(addresses);
+    }
+
+    private Long extractUserId(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalStateException("Authenticated user not found");
+        }
+        return Long.parseLong(authentication.getPrincipal().toString());
+    }
+}

--- a/src/main/java/com/foodify/server/modules/addresses/application/SavedAddressService.java
+++ b/src/main/java/com/foodify/server/modules/addresses/application/SavedAddressService.java
@@ -1,0 +1,74 @@
+package com.foodify.server.modules.addresses.application;
+
+import com.foodify.server.modules.addresses.domain.SavedAddress;
+import com.foodify.server.modules.addresses.dto.SaveAddressRequest;
+import com.foodify.server.modules.addresses.dto.SavedAddressResponse;
+import com.foodify.server.modules.addresses.mapper.SavedAddressMapper;
+import com.foodify.server.modules.addresses.repository.SavedAddressRepository;
+import com.foodify.server.modules.identity.domain.User;
+import com.foodify.server.modules.identity.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SavedAddressService {
+
+    private final SavedAddressRepository savedAddressRepository;
+    private final UserRepository userRepository;
+    private final SavedAddressMapper savedAddressMapper;
+
+    @Transactional
+    public SavedAddressResponse createAddress(Long userId, SaveAddressRequest request) {
+        User user = loadUser(userId);
+        SavedAddress savedAddress = new SavedAddress();
+        savedAddress.setUser(user);
+        savedAddressMapper.updateEntityFromRequest(savedAddress, request);
+        SavedAddress persisted = savedAddressRepository.save(savedAddress);
+        handlePrimaryFlag(userId, persisted.getPrimary(), persisted.getId());
+        return savedAddressMapper.toResponse(persisted);
+    }
+
+    @Transactional
+    public SavedAddressResponse updateAddress(Long userId, UUID addressId, SaveAddressRequest request) {
+        SavedAddress existing = savedAddressRepository.findByIdAndUserId(addressId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("Address not found"));
+
+        savedAddressMapper.updateEntityFromRequest(existing, request);
+        SavedAddress persisted = savedAddressRepository.save(existing);
+        handlePrimaryFlag(userId, persisted.getPrimary(), persisted.getId());
+        return savedAddressMapper.toResponse(persisted);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavedAddressResponse> getAddressesForUser(Long userId) {
+        return savedAddressRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(savedAddressMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    private User loadUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+    }
+
+    private void handlePrimaryFlag(Long userId, Boolean isPrimary, UUID currentAddressId) {
+        if (Boolean.TRUE.equals(isPrimary)) {
+            List<SavedAddress> addresses = savedAddressRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+            for (SavedAddress address : addresses) {
+                if (Boolean.TRUE.equals(address.getPrimary())
+                        && (currentAddressId == null || !currentAddressId.equals(address.getId()))) {
+                    address.setPrimary(false);
+                }
+            }
+            savedAddressRepository.saveAll(addresses);
+        }
+    }
+}

--- a/src/main/java/com/foodify/server/modules/addresses/domain/AddressType.java
+++ b/src/main/java/com/foodify/server/modules/addresses/domain/AddressType.java
@@ -1,0 +1,8 @@
+package com.foodify.server.modules.addresses.domain;
+
+public enum AddressType {
+    HOME,
+    APARTMENT,
+    WORK,
+    OTHER
+}

--- a/src/main/java/com/foodify/server/modules/addresses/domain/GeoCoordinates.java
+++ b/src/main/java/com/foodify/server/modules/addresses/domain/GeoCoordinates.java
@@ -1,0 +1,21 @@
+package com.foodify.server.modules.addresses.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+public class GeoCoordinates {
+
+    @Column(name = "latitude", precision = 9, scale = 6)
+    private Double latitude;
+
+    @Column(name = "longitude", precision = 9, scale = 6)
+    private Double longitude;
+
+    @Column(name = "geohash")
+    private String geohash;
+}

--- a/src/main/java/com/foodify/server/modules/addresses/domain/SavedAddress.java
+++ b/src/main/java/com/foodify/server/modules/addresses/domain/SavedAddress.java
@@ -1,0 +1,78 @@
+package com.foodify.server.modules.addresses.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.foodify.server.modules.addresses.domain.converter.JsonNodeAttributeConverter;
+import com.foodify.server.modules.identity.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "saved_addresses")
+@Getter
+@Setter
+@ToString(exclude = {"user"})
+public class SavedAddress {
+
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 32)
+    private AddressType type;
+
+    @Column(name = "label")
+    private String label;
+
+    @Embedded
+    private GeoCoordinates coordinates;
+
+    @Column(name = "formatted_address", nullable = false)
+    private String formattedAddress;
+
+    @Column(name = "place_id")
+    private String placeId;
+
+    @Column(name = "entrance_preference")
+    private String entrancePreference;
+
+    @Column(name = "entrance_notes", columnDefinition = "TEXT")
+    private String entranceNotes;
+
+    @Column(name = "directions", columnDefinition = "TEXT")
+    private String directions;
+
+    @Column(name = "internal_notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @Column(name = "is_primary")
+    private Boolean primary = Boolean.FALSE;
+
+    @Convert(converter = JsonNodeAttributeConverter.class)
+    @Column(name = "type_details", columnDefinition = "TEXT")
+    private JsonNode typeDetails;
+
+    @Convert(converter = JsonNodeAttributeConverter.class)
+    @Column(name = "metadata", columnDefinition = "TEXT")
+    private JsonNode metadata;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/src/main/java/com/foodify/server/modules/addresses/domain/converter/JsonNodeAttributeConverter.java
+++ b/src/main/java/com/foodify/server/modules/addresses/domain/converter/JsonNodeAttributeConverter.java
@@ -1,0 +1,42 @@
+package com.foodify.server.modules.addresses.domain.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Converter(autoApply = false)
+public class JsonNodeAttributeConverter implements AttributeConverter<JsonNode, String> {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonNodeAttributeConverter.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(JsonNode attribute) {
+        if (attribute == null || attribute.isNull() || attribute.isMissingNode()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize JsonNode attribute", e);
+            throw new IllegalArgumentException("Unable to serialize JSON attribute", e);
+        }
+    }
+
+    @Override
+    public JsonNode convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readTree(dbData);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize JsonNode attribute", e);
+            throw new IllegalArgumentException("Unable to deserialize JSON attribute", e);
+        }
+    }
+}

--- a/src/main/java/com/foodify/server/modules/addresses/dto/CoordinatesDto.java
+++ b/src/main/java/com/foodify/server/modules/addresses/dto/CoordinatesDto.java
@@ -1,0 +1,23 @@
+package com.foodify.server.modules.addresses.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CoordinatesDto {
+    @NotNull
+    @DecimalMin(value = "-90.0")
+    @DecimalMax(value = "90.0")
+    private Double latitude;
+
+    @NotNull
+    @DecimalMin(value = "-180.0")
+    @DecimalMax(value = "180.0")
+    private Double longitude;
+
+    private String geohash;
+}

--- a/src/main/java/com/foodify/server/modules/addresses/dto/SaveAddressRequest.java
+++ b/src/main/java/com/foodify/server/modules/addresses/dto/SaveAddressRequest.java
@@ -1,0 +1,44 @@
+package com.foodify.server.modules.addresses.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.foodify.server.modules.addresses.domain.AddressType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SaveAddressRequest {
+
+    private String userId;
+
+    @NotNull
+    private AddressType type;
+
+    private String label;
+
+    @NotNull
+    @Valid
+    private CoordinatesDto coordinates;
+
+    @NotBlank
+    private String formattedAddress;
+
+    private String placeId;
+
+    private String entrancePreference;
+
+    private String entranceNotes;
+
+    private String directions;
+
+    private String notes;
+
+    private Boolean isPrimary;
+
+    private JsonNode typeDetails;
+
+    private JsonNode metadata;
+}

--- a/src/main/java/com/foodify/server/modules/addresses/dto/SavedAddressResponse.java
+++ b/src/main/java/com/foodify/server/modules/addresses/dto/SavedAddressResponse.java
@@ -1,0 +1,30 @@
+package com.foodify.server.modules.addresses.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.foodify.server.modules.addresses.domain.AddressType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class SavedAddressResponse {
+    private final UUID id;
+    private final Long userId;
+    private final AddressType type;
+    private final String label;
+    private final CoordinatesDto coordinates;
+    private final String formattedAddress;
+    private final String placeId;
+    private final String entrancePreference;
+    private final String entranceNotes;
+    private final String directions;
+    private final String notes;
+    private final boolean primary;
+    private final JsonNode typeDetails;
+    private final JsonNode metadata;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+}

--- a/src/main/java/com/foodify/server/modules/addresses/mapper/SavedAddressMapper.java
+++ b/src/main/java/com/foodify/server/modules/addresses/mapper/SavedAddressMapper.java
@@ -1,0 +1,69 @@
+package com.foodify.server.modules.addresses.mapper;
+
+import com.foodify.server.modules.addresses.domain.GeoCoordinates;
+import com.foodify.server.modules.addresses.domain.SavedAddress;
+import com.foodify.server.modules.addresses.dto.CoordinatesDto;
+import com.foodify.server.modules.addresses.dto.SaveAddressRequest;
+import com.foodify.server.modules.addresses.dto.SavedAddressResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SavedAddressMapper {
+
+    public void updateEntityFromRequest(SavedAddress entity, SaveAddressRequest request) {
+        entity.setType(request.getType());
+        entity.setLabel(request.getLabel());
+        entity.setFormattedAddress(request.getFormattedAddress());
+        entity.setPlaceId(request.getPlaceId());
+        entity.setEntrancePreference(request.getEntrancePreference());
+        entity.setEntranceNotes(request.getEntranceNotes());
+        entity.setDirections(request.getDirections());
+        entity.setNotes(request.getNotes());
+        entity.setPrimary(Boolean.TRUE.equals(request.getIsPrimary()));
+        entity.setTypeDetails(request.getTypeDetails());
+        entity.setMetadata(request.getMetadata());
+
+        if (request.getCoordinates() != null) {
+            CoordinatesDto coordinatesDto = request.getCoordinates();
+            GeoCoordinates coordinates = entity.getCoordinates();
+            if (coordinates == null) {
+                coordinates = new GeoCoordinates();
+            }
+            coordinates.setLatitude(coordinatesDto.getLatitude());
+            coordinates.setLongitude(coordinatesDto.getLongitude());
+            coordinates.setGeohash(coordinatesDto.getGeohash());
+            entity.setCoordinates(coordinates);
+        } else {
+            entity.setCoordinates(null);
+        }
+    }
+
+    public SavedAddressResponse toResponse(SavedAddress entity) {
+        CoordinatesDto coordinatesDto = null;
+        if (entity.getCoordinates() != null) {
+            coordinatesDto = new CoordinatesDto();
+            coordinatesDto.setLatitude(entity.getCoordinates().getLatitude());
+            coordinatesDto.setLongitude(entity.getCoordinates().getLongitude());
+            coordinatesDto.setGeohash(entity.getCoordinates().getGeohash());
+        }
+
+        return SavedAddressResponse.builder()
+                .id(entity.getId())
+                .userId(entity.getUser() != null ? entity.getUser().getId() : null)
+                .type(entity.getType())
+                .label(entity.getLabel())
+                .coordinates(coordinatesDto)
+                .formattedAddress(entity.getFormattedAddress())
+                .placeId(entity.getPlaceId())
+                .entrancePreference(entity.getEntrancePreference())
+                .entranceNotes(entity.getEntranceNotes())
+                .directions(entity.getDirections())
+                .notes(entity.getNotes())
+                .primary(Boolean.TRUE.equals(entity.getPrimary()))
+                .typeDetails(entity.getTypeDetails())
+                .metadata(entity.getMetadata())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/foodify/server/modules/addresses/repository/SavedAddressRepository.java
+++ b/src/main/java/com/foodify/server/modules/addresses/repository/SavedAddressRepository.java
@@ -1,0 +1,14 @@
+package com.foodify.server.modules.addresses.repository;
+
+import com.foodify.server.modules.addresses.domain.SavedAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SavedAddressRepository extends JpaRepository<SavedAddress, UUID> {
+    List<SavedAddress> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<SavedAddress> findByIdAndUserId(UUID id, Long userId);
+}

--- a/src/main/java/com/foodify/server/modules/identity/domain/User.java
+++ b/src/main/java/com/foodify/server/modules/identity/domain/User.java
@@ -1,11 +1,16 @@
 package com.foodify.server.modules.identity.domain;
 
-import com.foodify.server.modules.identity.domain.AuthProvider;
-import com.foodify.server.modules.identity.domain.Role;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.foodify.server.modules.addresses.domain.SavedAddress;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Data
@@ -28,4 +33,10 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @JsonIgnore
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SavedAddress> savedAddresses = new ArrayList<>();
 }


### PR DESCRIPTION
## Summary
- add address domain model with JSON-backed metadata and coordinate support linked to users
- implement service, mapper, and repository to manage saved addresses and primary flag handling
- expose secured endpoints for creating, updating, and listing the authenticated client’s saved addresses

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68de8d2b6ba0832ca6c86b2380e0ffbd