### PR TITLE
Fix order extras join table column

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,11 +33,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	implementation 'org.springframework.kafka:spring-kafka:3.1.1'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'com.google.firebase:firebase-admin:9.1.1' // latest version
-	implementation 'com.google.zxing:core:3.5.3'
-	implementation 'com.google.zxing:javase:3.5.3'
-	implementation 'com.google.maps:google-maps-routing:1.58.0'
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+        implementation 'com.google.firebase:firebase-admin:9.1.1' // latest version
+        implementation 'com.google.zxing:core:3.5.3'
+        implementation 'com.google.zxing:javase:3.5.3'
+        implementation 'com.google.maps:google-maps-routing:1.58.0'
+        implementation 'org.flywaydb:flyway-core'
         annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
         runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
         runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // for JSON serialization

--- a/src/main/java/com/foodify/server/modules/orders/domain/OrderItem.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/OrderItem.java
@@ -26,7 +26,7 @@ public class OrderItem {
     @JoinTable(
             name = "order_item_menu_item_extras",
             joinColumns = @JoinColumn(name = "order_item_id"),
-            inverseJoinColumns = @JoinColumn(name = "menu_item_extra_id")
+            inverseJoinColumns = @JoinColumn(name = "menu_item_extras_id")
     )
     private List<MenuItemExtra> menuItemExtras;
 

--- a/src/main/resources/db/migration/V1__recreate_order_item_menu_item_extras_table.sql
+++ b/src/main/resources/db/migration/V1__recreate_order_item_menu_item_extras_table.sql
@@ -1,0 +1,12 @@
+-- Ensure the order_item_menu_item_extras join table uses the correct column name
+DROP TABLE IF EXISTS order_item_menu_item_extras;
+
+CREATE TABLE order_item_menu_item_extras (
+    order_item_id BIGINT NOT NULL,
+    menu_item_extras_id BIGINT NOT NULL
+);
+
+ALTER TABLE order_item_menu_item_extras
+    ADD CONSTRAINT fk_order_item_menu_item_extras_order FOREIGN KEY (order_item_id) REFERENCES order_item(id);
+ALTER TABLE order_item_menu_item_extras
+    ADD CONSTRAINT fk_order_item_menu_item_extras_extra FOREIGN KEY (menu_item_extras_id) REFERENCES menu_item_extra(id);


### PR DESCRIPTION
## Summary
- point the order item extras join table mapping at the correct column name
- add Flyway support and a migration that recreates the join table with the expected column names and foreign keys

## Testing
- ./gradlew test *(fails: required Java 17 toolchain is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68dfbb4ca694832cb171560387a660bd