### PR TITLE
Fix entity mappings for PostgreSQL compatibility

### DIFF
--- a/src/main/java/com/foodify/server/modules/addresses/domain/SavedAddress.java
+++ b/src/main/java/com/foodify/server/modules/addresses/domain/SavedAddress.java
@@ -21,8 +21,8 @@ import java.util.UUID;
 public class SavedAddress {
 
     @Id
-    @GeneratedValue
-    @Column(columnDefinition = "BINARY(16)")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/foodify/server/modules/notifications/domain/UserDevice.java
+++ b/src/main/java/com/foodify/server/modules/notifications/domain/UserDevice.java
@@ -3,6 +3,8 @@ package com.foodify.server.modules.notifications.domain;
 import com.foodify.server.modules.identity.domain.User;
 import jakarta.persistence.*;
 import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -23,12 +25,21 @@ public class UserDevice {
     private String deviceId;
     private String appVersion;
 
-    @Column(columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "last_seen", nullable = false)
     private LocalDateTime lastSeen;
 
-    @Column(columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onPersist() {
+        if (lastSeen == null) {
+            lastSeen = LocalDateTime.now();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace the MySQL-specific binary column definition on saved addresses with a UUID-friendly mapping
- rework user device timestamp columns to rely on Hibernate auditing annotations instead of MySQL-specific defaults

## Testing
- ./gradlew test *(fails: missing Java toolchain in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68dfce481ab4832c9bf4b751200a14cc