### PR TITLE
Refactor client my-orders endpoint to return OrderDto list

### DIFF
--- a/src/main/java/com/foodify/server/modules/customers/api/ClientController.java
+++ b/src/main/java/com/foodify/server/modules/customers/api/ClientController.java
@@ -3,6 +3,7 @@ package com.foodify.server.modules.customers.api;
 import com.foodify.server.modules.customers.application.ClientService;
 import com.foodify.server.modules.identity.repository.ClientRepository;
 import com.foodify.server.modules.orders.domain.Order;
+import com.foodify.server.modules.orders.dto.OrderDto;
 import com.foodify.server.modules.restaurants.application.RestaurantDetailsService;
 import com.foodify.server.modules.restaurants.domain.Restaurant;
 import com.foodify.server.modules.restaurants.dto.RestaurantDetailsResponse;
@@ -42,7 +43,7 @@ public class ClientController {
     }
     @PreAuthorize("hasAuthority('ROLE_CLIENT')")
     @GetMapping("/my-orders")
-    public List<Order> getMyOrders(Authentication authentication) {
+    public List<OrderDto> getMyOrders(Authentication authentication) {
         Long userId = Long.parseLong((String)authentication.getPrincipal());
         return this.clientService.getMyOrders(clientRepository.findById(userId).orElse(null));
     }

--- a/src/main/java/com/foodify/server/modules/customers/application/ClientService.java
+++ b/src/main/java/com/foodify/server/modules/customers/application/ClientService.java
@@ -2,6 +2,8 @@ package com.foodify.server.modules.customers.application;
 
 import com.foodify.server.modules.identity.domain.Client;
 import com.foodify.server.modules.orders.domain.Order;
+import com.foodify.server.modules.orders.dto.OrderDto;
+import com.foodify.server.modules.orders.mapper.OrderMapper;
 import com.foodify.server.modules.identity.repository.ClientRepository;
 import com.foodify.server.modules.orders.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +19,15 @@ public class ClientService {
     private final OrderRepository  orderRepository;
 
 
-    public List<Order> getMyOrders(Client client) {
-        return this.orderRepository.findAllByClientOrderByDateDesc(client);
+    public List<OrderDto> getMyOrders(Client client) {
+        if (client == null) {
+            return List.of();
+        }
+
+        return this.orderRepository.findAllByClientOrderByDateDesc(client)
+                .stream()
+                .map(OrderMapper::toDto)
+                .toList();
     }
 
     public Order getMyOrder(Long id) {


### PR DESCRIPTION
## Summary
- update the client my-orders endpoint to return `OrderDto` objects instead of domain entities
- map client orders to DTOs in the service layer and gracefully handle missing clients

## Testing
- ./gradlew test *(fails: Java 17 toolchain missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e034729c44832c91187e351b700247