### PR TITLE
Expand order notification payload for richer client UI

### DIFF
--- a/src/main/java/com/foodify/server/modules/orders/dto/OrderNotificationDTO.java
+++ b/src/main/java/com/foodify/server/modules/orders/dto/OrderNotificationDTO.java
@@ -1,5 +1,8 @@
 package com.foodify.server.modules.orders.dto;
 
+import com.foodify.server.modules.orders.domain.OrderLifecycleAction;
+import com.foodify.server.modules.orders.domain.OrderStatus;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -10,5 +13,45 @@ public record OrderNotificationDTO(
         LocalDateTime date,
         List<OrderItemDTO> items,
         SavedAddressSummaryDto savedAddress,
-        ClientSummaryDTO client
-) {}
+        ClientSummaryDTO client,
+        OrderStatus status,
+        LocationDto deliveryLocation,
+        RestaurantSummary restaurant,
+        DeliverySummary delivery,
+        List<OrderStatusHistoryDTO> statusHistory
+) {
+
+    public record RestaurantSummary(
+            Long id,
+            String name,
+            String address,
+            String phone,
+            String imageUrl,
+            LocationDto location
+    ) {}
+
+    public record DeliverySummary(
+            Long id,
+            DriverSummary driver,
+            Long estimatedPickupTime,
+            Long estimatedDeliveryTime,
+            LocalDateTime pickupTime,
+            LocalDateTime deliveredTime
+    ) {}
+
+    public record DriverSummary(
+            Long id,
+            String name,
+            String phone
+    ) {}
+
+    public record OrderStatusHistoryDTO(
+            OrderLifecycleAction action,
+            OrderStatus previousStatus,
+            OrderStatus newStatus,
+            String changedBy,
+            String reason,
+            String metadata,
+            LocalDateTime changedAt
+    ) {}
+}

--- a/src/main/java/com/foodify/server/modules/orders/mapper/OrderNotificationMapper.java
+++ b/src/main/java/com/foodify/server/modules/orders/mapper/OrderNotificationMapper.java
@@ -1,33 +1,132 @@
 package com.foodify.server.modules.orders.mapper;
 
+import com.foodify.server.modules.delivery.domain.Delivery;
+import com.foodify.server.modules.identity.domain.Driver;
+import com.foodify.server.modules.orders.domain.Order;
+import com.foodify.server.modules.orders.domain.OrderStatusHistory;
 import com.foodify.server.modules.orders.dto.ClientSummaryDTO;
+import com.foodify.server.modules.orders.dto.LocationDto;
 import com.foodify.server.modules.orders.dto.OrderItemDTO;
 import com.foodify.server.modules.orders.dto.OrderNotificationDTO;
-import com.foodify.server.modules.orders.domain.Order;
 import com.foodify.server.modules.restaurants.domain.MenuItemExtra;
+import com.foodify.server.modules.restaurants.domain.Restaurant;
 import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 @Component
 public class OrderNotificationMapper {
 
     public OrderNotificationDTO toDto(Order order) {
+        LocationDto deliveryLocation = resolveDeliveryLocation(order);
+        OrderNotificationDTO.RestaurantSummary restaurantSummary = toRestaurantSummary(order.getRestaurant());
+        OrderNotificationDTO.DeliverySummary deliverySummary = toDeliverySummary(order.getDelivery());
+
+        List<OrderItemDTO> items = order.getItems() == null ? List.of() : order.getItems().stream().map(item -> new OrderItemDTO(
+                item.getMenuItem().getId(),
+                item.getMenuItem().getName(),
+                item.getQuantity(),
+                item.getMenuItemExtras().stream().map(MenuItemExtra::getName).toList(),
+                item.getSpecialInstructions()
+        )).toList();
+
         return new OrderNotificationDTO(
                 order.getId(),
                 order.getDeliveryAddress(),
                 order.getPaymentMethod(),
                 order.getDate(),
-                order.getItems().stream().map(item -> new OrderItemDTO(
-                        item.getMenuItem().getId(),
-                        item.getMenuItem().getName(),
-                        item.getQuantity(),
-                        item.getMenuItemExtras().stream().map(MenuItemExtra::getName).toList(),
-                        item.getSpecialInstructions()
-                )).toList(),
+                items,
                 SavedAddressSummaryMapper.from(order.getSavedAddress()),
                 new ClientSummaryDTO(
                         order.getClient().getId(),
                         order.getClient().getName()
-                )
+                ),
+                order.getStatus(),
+                deliveryLocation,
+                restaurantSummary,
+                deliverySummary,
+                buildStatusHistory(order)
         );
+    }
+
+    private LocationDto resolveDeliveryLocation(Order order) {
+        LocationDto fromSavedAddress = SavedAddressSummaryMapper.toLocation(order.getSavedAddress());
+        if (fromSavedAddress != null) {
+            return fromSavedAddress;
+        }
+
+        double lat = order.getLat();
+        double lng = order.getLng();
+        if (lat == 0.0 && lng == 0.0) {
+            return null;
+        }
+        return new LocationDto(lat, lng);
+    }
+
+    private OrderNotificationDTO.RestaurantSummary toRestaurantSummary(Restaurant restaurant) {
+        if (restaurant == null) {
+            return null;
+        }
+        LocationDto location = null;
+        double latitude = restaurant.getLatitude();
+        double longitude = restaurant.getLongitude();
+        if (!(latitude == 0.0 && longitude == 0.0)) {
+            location = new LocationDto(latitude, longitude);
+        }
+        return new OrderNotificationDTO.RestaurantSummary(
+                restaurant.getId(),
+                restaurant.getName(),
+                restaurant.getAddress(),
+                restaurant.getPhone(),
+                restaurant.getImageUrl(),
+                location
+        );
+    }
+
+    private OrderNotificationDTO.DeliverySummary toDeliverySummary(Delivery delivery) {
+        if (delivery == null) {
+            return null;
+        }
+
+        Driver driver = delivery.getDriver();
+        OrderNotificationDTO.DriverSummary driverSummary = null;
+        if (driver != null) {
+            driverSummary = new OrderNotificationDTO.DriverSummary(
+                    driver.getId(),
+                    driver.getName(),
+                    driver.getPhone()
+            );
+        }
+
+        return new OrderNotificationDTO.DeliverySummary(
+                delivery.getId(),
+                driverSummary,
+                delivery.getTimeToPickUp(),
+                delivery.getDeliveryTime(),
+                delivery.getPickupTime(),
+                delivery.getDeliveredTime()
+        );
+    }
+
+    private List<OrderNotificationDTO.OrderStatusHistoryDTO> buildStatusHistory(Order order) {
+        if (order.getStatusHistory() == null) {
+            return List.of();
+        }
+
+        return order.getStatusHistory().stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(OrderStatusHistory::getChangedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(history -> new OrderNotificationDTO.OrderStatusHistoryDTO(
+                        history.getAction(),
+                        history.getPreviousStatus(),
+                        history.getNewStatus(),
+                        history.getChangedBy(),
+                        history.getReason(),
+                        history.getMetadata(),
+                        history.getChangedAt()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/foodify/server/modules/orders/repository/OrderRepository.java
+++ b/src/main/java/com/foodify/server/modules/orders/repository/OrderRepository.java
@@ -25,7 +25,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             "items",
             "items.menuItem",
             "pendingDriver",
-            "savedAddress"
+            "savedAddress",
+            "statusHistory"
     })
     Optional<Order> findDetailedById(Long id);
     @Query("""


### PR DESCRIPTION
## Summary
- extend the order notification DTO to include restaurant, delivery, location, and status history details needed for the tracking screen
- update the mapper to populate the expanded payload and gracefully handle missing data
- load order status history in the detailed order query used for notifications

## Testing
- `./gradlew test` *(fails: no Java 17 toolchain configured in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e1567b9720832c8a4519e94cfcccc6