### PR TITLE
Add restaurant search API with filtering and pagination

### DIFF
--- a/src/main/java/com/foodify/server/modules/restaurants/api/ClientRestaurantController.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/api/ClientRestaurantController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/client/restaurants")
+@RequestMapping("/api/client/restaurants")
 public class ClientRestaurantController {
 
     private final RestaurantSearchService restaurantSearchService;

--- a/src/main/java/com/foodify/server/modules/restaurants/api/ClientRestaurantController.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/api/ClientRestaurantController.java
@@ -1,0 +1,46 @@
+package com.foodify.server.modules.restaurants.api;
+
+import com.foodify.server.modules.restaurants.application.RestaurantSearchService;
+import com.foodify.server.modules.restaurants.dto.PageResponse;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchItemDto;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchQuery;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchSort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/client/restaurants")
+public class ClientRestaurantController {
+
+    private final RestaurantSearchService restaurantSearchService;
+
+    @GetMapping("/search")
+    public PageResponse<RestaurantSearchItemDto> search(
+            @RequestParam(defaultValue = "") String query,
+            @RequestParam(required = false) Boolean hasPromotion,
+            @RequestParam(required = false) Boolean isTopChoice,
+            @RequestParam(required = false) Boolean hasFreeDelivery,
+            @RequestParam(required = false) String sort,
+            @RequestParam(required = false) Boolean topEatOnly,
+            @RequestParam(required = false) Double maxDeliveryFee,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer pageSize
+    ) {
+        RestaurantSearchQuery searchQuery = new RestaurantSearchQuery(
+                query,
+                hasPromotion,
+                isTopChoice,
+                hasFreeDelivery,
+                RestaurantSearchSort.fromNullable(sort),
+                topEatOnly,
+                maxDeliveryFee,
+                page,
+                pageSize
+        );
+        return restaurantSearchService.search(searchQuery);
+    }
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantDetailsService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantDetailsService.java
@@ -62,7 +62,7 @@ public class RestaurantDetailsService {
     private List<RestaurantDetailsResponse.RestaurantBadge> buildHighlights(Restaurant restaurant) {
         List<RestaurantDetailsResponse.RestaurantBadge> highlights = new ArrayList<>();
         if (restaurant.getRating() != null) {
-            highlights.add(new RestaurantDetailsResponse.RestaurantBadge("Rating", restaurant.getRating()));
+            highlights.add(new RestaurantDetailsResponse.RestaurantBadge("Rating", formatRating(restaurant.getRating())));
         }
         if (restaurant.getType() != null) {
             highlights.add(new RestaurantDetailsResponse.RestaurantBadge("Category", restaurant.getType()));
@@ -75,6 +75,10 @@ public class RestaurantDetailsService {
             highlights.add(new RestaurantDetailsResponse.RestaurantBadge("Address", restaurant.getAddress()));
         }
         return highlights;
+    }
+
+    private String formatRating(Double rating) {
+        return rating == null ? null : String.format(Locale.ROOT, "%.1f", rating);
     }
 
     private Map<String, List<MenuItem>> groupByCategory(List<MenuItem> menuItems) {

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantDetailsService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantDetailsService.java
@@ -109,6 +109,7 @@ public class RestaurantDetailsService {
     }
 
     private RestaurantDetailsResponse.MenuItemSummary toSummary(MenuItem item) {
+        boolean promotionActive = Boolean.TRUE.equals(item.getPromotionActive());
         return new RestaurantDetailsResponse.MenuItemSummary(
                 item.getId(),
                 item.getName(),
@@ -116,7 +117,10 @@ public class RestaurantDetailsService {
                 item.getPrice(),
                 firstImage(item),
                 item.isPopular(),
-                buildTags(item)
+                buildTags(item, promotionActive),
+                item.getPromotionPrice(),
+                item.getPromotionLabel(),
+                promotionActive
         );
     }
 
@@ -132,6 +136,7 @@ public class RestaurantDetailsService {
     }
 
     private RestaurantDetailsResponse.MenuItemDetails toDetails(MenuItem item) {
+        boolean promotionActive = Boolean.TRUE.equals(item.getPromotionActive());
         return new RestaurantDetailsResponse.MenuItemDetails(
                 item.getId(),
                 item.getName(),
@@ -139,7 +144,10 @@ public class RestaurantDetailsService {
                 item.getPrice(),
                 firstImage(item),
                 item.isPopular(),
-                buildTags(item),
+                buildTags(item, promotionActive),
+                item.getPromotionPrice(),
+                item.getPromotionLabel(),
+                promotionActive,
                 item.getOptionGroups() == null ? List.of() : item.getOptionGroups().stream()
                         .map(this::toOptionGroup)
                         .toList()
@@ -168,13 +176,16 @@ public class RestaurantDetailsService {
         );
     }
 
-    private List<String> buildTags(MenuItem item) {
+    private List<String> buildTags(MenuItem item, boolean promotionActive) {
         Set<String> tags = new java.util.LinkedHashSet<>();
         if (item.getCategory() != null) {
             tags.add(item.getCategory());
         }
         if (item.isPopular()) {
             tags.add("Top Sales");
+        }
+        if (promotionActive) {
+            tags.add("Promo");
         }
         tags.add(item.getRestaurant().getName());
         return new ArrayList<>(tags);

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
@@ -1,0 +1,105 @@
+package com.foodify.server.modules.restaurants.application;
+
+import com.foodify.server.modules.restaurants.domain.Restaurant;
+import com.foodify.server.modules.restaurants.dto.PageResponse;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchItemDto;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchQuery;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchSort;
+import com.foodify.server.modules.restaurants.repository.RestaurantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class RestaurantSearchService {
+
+    private final RestaurantRepository restaurantRepository;
+
+    public PageResponse<RestaurantSearchItemDto> search(RestaurantSearchQuery query) {
+        Specification<Restaurant> specification = buildSpecification(query);
+        Sort sort = toSort(query.sort());
+        int page = query.page() != null && query.page() > 0 ? query.page() : 1;
+        int pageSize = query.pageSize() != null && query.pageSize() > 0 ? query.pageSize() : 20;
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), pageSize, sort);
+
+        Page<Restaurant> restaurants = restaurantRepository.findAll(specification, pageable);
+        List<RestaurantSearchItemDto> items = restaurants.getContent().stream()
+                .map(this::toDto)
+                .toList();
+
+        return new PageResponse<>(items, page, pageSize, restaurants.getTotalElements());
+    }
+
+    private RestaurantSearchItemDto toDto(Restaurant restaurant) {
+        return new RestaurantSearchItemDto(
+                restaurant.getId(),
+                restaurant.getName(),
+                restaurant.getDeliveryTimeRange(),
+                restaurant.getRating(),
+                restaurant.isTopChoice(),
+                restaurant.isFreeDelivery(),
+                restaurant.getPromotionLabel(),
+                restaurant.getImageUrl()
+        );
+    }
+
+    private Sort toSort(RestaurantSearchSort sort) {
+        RestaurantSearchSort effectiveSort = sort == null ? RestaurantSearchSort.PICKED : sort;
+        return switch (effectiveSort) {
+            case POPULAR -> Sort.by(Sort.Order.desc("topEat"), Sort.Order.desc("rating"), Sort.Order.asc("name"));
+            case RATING -> Sort.by(Sort.Order.desc("rating"), Sort.Order.asc("name"));
+            case PICKED -> Sort.by(Sort.Order.desc("topChoice"), Sort.Order.desc("rating"), Sort.Order.asc("name"));
+        };
+    }
+
+    private Specification<Restaurant> buildSpecification(RestaurantSearchQuery query) {
+        Specification<Restaurant> specification = Specification.where(null);
+        if (query == null) {
+            return specification;
+        }
+
+        if (query.query() != null && !query.query().isBlank()) {
+            String like = "%" + query.query().toLowerCase(Locale.ROOT) + "%";
+            specification = specification.and((root, cq, cb) -> cb.or(
+                    cb.like(cb.lower(root.get("name")), like),
+                    cb.like(cb.lower(root.get("description")), like)
+            ));
+        }
+
+        if (Boolean.TRUE.equals(query.hasPromotion())) {
+            specification = specification.and((root, cq, cb) -> cb.and(
+                    cb.isNotNull(root.get("promotionLabel")),
+                    cb.notEqual(cb.lower(root.get("promotionLabel")), "")
+            ));
+        }
+
+        if (Boolean.TRUE.equals(query.isTopChoice())) {
+            specification = specification.and((root, cq, cb) -> cb.isTrue(root.get("topChoice")));
+        }
+
+        if (Boolean.TRUE.equals(query.hasFreeDelivery())) {
+            specification = specification.and((root, cq, cb) -> cb.isTrue(root.get("freeDelivery")));
+        }
+
+        if (Boolean.TRUE.equals(query.topEatOnly())) {
+            specification = specification.and((root, cq, cb) -> cb.isTrue(root.get("topEat")));
+        }
+
+        if (query.maxDeliveryFee() != null) {
+            specification = specification.and((root, cq, cb) -> cb.or(
+                    cb.isNull(root.get("deliveryFee")),
+                    cb.lessThanOrEqualTo(root.get("deliveryFee"), query.maxDeliveryFee())
+            ));
+        }
+
+        return specification;
+    }
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
@@ -70,10 +70,6 @@ public class RestaurantSearchService {
         List<MenuItemPromotionDto> promotedMenuItems = promotedItems == null ? List.of() : promotedItems.stream()
                 .map(this::toPromotionDto)
                 .toList();
-        String promotionLabel = restaurant.getPromotionLabel();
-        if ((promotionLabel == null || promotionLabel.isBlank()) && !promotedMenuItems.isEmpty()) {
-            promotionLabel = promotedMenuItems.get(0).promotionLabel();
-        }
         return new RestaurantSearchItemDto(
                 restaurant.getId(),
                 restaurant.getName(),
@@ -81,7 +77,6 @@ public class RestaurantSearchService {
                 restaurant.getRating(),
                 Boolean.TRUE.equals(restaurant.getTopChoice()),
                 Boolean.TRUE.equals(restaurant.getFreeDelivery()),
-                promotionLabel,
                 restaurant.getImageUrl(),
                 promotedMenuItems
         );

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
@@ -93,8 +93,15 @@ public class RestaurantSearchService {
                 menuItem.getName(),
                 menuItem.getPrice(),
                 menuItem.getPromotionPrice(),
-                menuItem.getPromotionLabel()
+                menuItem.getPromotionLabel(),
+                firstImage(menuItem)
         );
+    }
+
+    private String firstImage(MenuItem item) {
+        return (item.getImageUrls() != null && !item.getImageUrls().isEmpty())
+                ? item.getImageUrls().get(0)
+                : null;
     }
 
     private Sort toSort(RestaurantSearchSort sort) {

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantSearchService.java
@@ -44,8 +44,8 @@ public class RestaurantSearchService {
                 restaurant.getName(),
                 restaurant.getDeliveryTimeRange(),
                 restaurant.getRating(),
-                restaurant.isTopChoice(),
-                restaurant.isFreeDelivery(),
+                Boolean.TRUE.equals(restaurant.getTopChoice()),
+                Boolean.TRUE.equals(restaurant.getFreeDelivery()),
                 restaurant.getPromotionLabel(),
                 restaurant.getImageUrl()
         );

--- a/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantService.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/application/RestaurantService.java
@@ -155,6 +155,9 @@ public class RestaurantService {
         item.setCategory(menuDto.getCategory());
         item.setPopular(menuDto.isPopular());
         item.setImageUrls(imageFilenames);
+        item.setPromotionLabel(menuDto.getPromotionLabel());
+        item.setPromotionPrice(menuDto.getPromotionPrice());
+        item.setPromotionActive(menuDto.isPromotionActive());
 
         Restaurant restaurant = restaurantRepository.findById(menuDto.getRestaurantId())
                 .orElseThrow(() -> new RuntimeException("Restaurant not found"));

--- a/src/main/java/com/foodify/server/modules/restaurants/domain/MenuItem.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/domain/MenuItem.java
@@ -22,6 +22,15 @@ public class MenuItem {
     private boolean isPopular;
     private double price;
 
+    @Column(name = "promotion_label")
+    private String promotionLabel;
+
+    @Column(name = "promotion_price")
+    private Double promotionPrice;
+
+    @Column(name = "promotion_active")
+    private Boolean promotionActive = Boolean.FALSE;
+
     // Multiple images instead of just one
     @ElementCollection
     @CollectionTable(name = "menu_item_images", joinColumns = @JoinColumn(name = "menu_item_id"))

--- a/src/main/java/com/foodify/server/modules/restaurants/domain/Restaurant.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/domain/Restaurant.java
@@ -35,8 +35,6 @@ public class Restaurant {
     private Boolean freeDelivery = Boolean.FALSE;
     @Column(name = "top_eat")
     private Boolean topEat = Boolean.FALSE;
-    @Column(name = "promotion_label")
-    private String promotionLabel;
     @Column(name = "delivery_fee")
     private Double deliveryFee;
     @Column(name = "delivery_time_range")

--- a/src/main/java/com/foodify/server/modules/restaurants/domain/Restaurant.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/domain/Restaurant.java
@@ -30,11 +30,11 @@ public class Restaurant {
     private double longitude;
     private String imageUrl;
     @Column(name = "top_choice")
-    private boolean topChoice;
+    private Boolean topChoice = Boolean.FALSE;
     @Column(name = "free_delivery")
-    private boolean freeDelivery;
+    private Boolean freeDelivery = Boolean.FALSE;
     @Column(name = "top_eat")
-    private boolean topEat;
+    private Boolean topEat = Boolean.FALSE;
     @Column(name = "promotion_label")
     private String promotionLabel;
     @Column(name = "delivery_fee")

--- a/src/main/java/com/foodify/server/modules/restaurants/domain/Restaurant.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/domain/Restaurant.java
@@ -20,7 +20,7 @@ public class Restaurant {
     private String address;
     private String phone;
     private String type;
-    private String rating;
+    private Double rating;
     private String openingHours;
     private String closingHours;
     private String description;
@@ -29,6 +29,18 @@ public class Restaurant {
     private double latitude;
     private double longitude;
     private String imageUrl;
+    @Column(name = "top_choice")
+    private boolean topChoice;
+    @Column(name = "free_delivery")
+    private boolean freeDelivery;
+    @Column(name = "top_eat")
+    private boolean topEat;
+    @Column(name = "promotion_label")
+    private String promotionLabel;
+    @Column(name = "delivery_fee")
+    private Double deliveryFee;
+    @Column(name = "delivery_time_range")
+    private String deliveryTimeRange;
 
     @OneToOne
     @JoinColumn(name = "admin_id")

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/MenuItemPromotionDto.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/MenuItemPromotionDto.java
@@ -5,6 +5,7 @@ public record MenuItemPromotionDto(
         String name,
         double price,
         Double promotionPrice,
-        String promotionLabel
+        String promotionLabel,
+        String imageUrl
 ) {
 }

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/MenuItemPromotionDto.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/MenuItemPromotionDto.java
@@ -1,0 +1,10 @@
+package com.foodify.server.modules.restaurants.dto;
+
+public record MenuItemPromotionDto(
+        Long id,
+        String name,
+        double price,
+        Double promotionPrice,
+        String promotionLabel
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/MenuItemRequestDTO.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/MenuItemRequestDTO.java
@@ -15,6 +15,10 @@ public class MenuItemRequestDTO {
     private boolean popular;
     private Long restaurantId;
 
+    private String promotionLabel;
+    private Double promotionPrice;
+    private boolean promotionActive;
+
     // Multiple images
     private List<String> imageUrls;
 

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/PageResponse.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/PageResponse.java
@@ -1,0 +1,11 @@
+package com.foodify.server.modules.restaurants.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> items,
+        int page,
+        int pageSize,
+        long totalItems
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantDetailsResponse.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantDetailsResponse.java
@@ -29,7 +29,10 @@ public record RestaurantDetailsResponse(
             double price,
             String imageUrl,
             boolean popular,
-            List<String> tags
+            List<String> tags,
+            Double promotionPrice,
+            String promotionLabel,
+            boolean promotionActive
     ) {}
 
     public record MenuCategory(String name, List<MenuItemDetails> items) {}
@@ -42,6 +45,9 @@ public record RestaurantDetailsResponse(
             String imageUrl,
             boolean popular,
             List<String> tags,
+            Double promotionPrice,
+            String promotionLabel,
+            boolean promotionActive,
             List<MenuOptionGroupDto> optionGroups
     ) {}
 

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantDetailsResponse.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantDetailsResponse.java
@@ -10,7 +10,7 @@ public record RestaurantDetailsResponse(
         String address,
         String phone,
         String type,
-        String rating,
+        Double rating,
         String openingHours,
         String closingHours,
         double latitude,

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantDisplayDto.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantDisplayDto.java
@@ -10,7 +10,7 @@ public class RestaurantDisplayDto {
     private Long id;
     private  String name;
     private String description;
-    private String rating;
+    private Double rating;
     private String type;
     private String address;
     private String phone;

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchItemDto.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchItemDto.java
@@ -9,7 +9,6 @@ public record RestaurantSearchItemDto(
         Double rating,
         boolean isTopChoice,
         boolean hasFreeDelivery,
-        String promotionLabel,
         String imageUrl,
         List<MenuItemPromotionDto> promotedMenuItems
 ) {

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchItemDto.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchItemDto.java
@@ -1,5 +1,7 @@
 package com.foodify.server.modules.restaurants.dto;
 
+import java.util.List;
+
 public record RestaurantSearchItemDto(
         Long id,
         String name,
@@ -8,6 +10,7 @@ public record RestaurantSearchItemDto(
         boolean isTopChoice,
         boolean hasFreeDelivery,
         String promotionLabel,
-        String imageUrl
+        String imageUrl,
+        List<MenuItemPromotionDto> promotedMenuItems
 ) {
 }

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchItemDto.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchItemDto.java
@@ -1,0 +1,13 @@
+package com.foodify.server.modules.restaurants.dto;
+
+public record RestaurantSearchItemDto(
+        Long id,
+        String name,
+        String deliveryTimeRange,
+        Double rating,
+        boolean isTopChoice,
+        boolean hasFreeDelivery,
+        String promotionLabel,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchQuery.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchQuery.java
@@ -1,0 +1,14 @@
+package com.foodify.server.modules.restaurants.dto;
+
+public record RestaurantSearchQuery(
+        String query,
+        Boolean hasPromotion,
+        Boolean isTopChoice,
+        Boolean hasFreeDelivery,
+        RestaurantSearchSort sort,
+        Boolean topEatOnly,
+        Double maxDeliveryFee,
+        Integer page,
+        Integer pageSize
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchSort.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/dto/RestaurantSearchSort.java
@@ -1,0 +1,20 @@
+package com.foodify.server.modules.restaurants.dto;
+
+import java.util.Locale;
+
+public enum RestaurantSearchSort {
+    PICKED,
+    POPULAR,
+    RATING;
+
+    public static RestaurantSearchSort fromNullable(String value) {
+        if (value == null || value.isBlank()) {
+            return PICKED;
+        }
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "popular" -> POPULAR;
+            case "rating" -> RATING;
+            default -> PICKED;
+        };
+    }
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/repository/MenuItemRepository.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/repository/MenuItemRepository.java
@@ -3,5 +3,8 @@ package com.foodify.server.modules.restaurants.repository;
 import com.foodify.server.modules.restaurants.domain.MenuItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MenuItemRepository extends JpaRepository<MenuItem, Long> {
+    List<MenuItem> findByRestaurant_IdInAndPromotionActiveTrue(List<Long> restaurantIds);
 }

--- a/src/main/java/com/foodify/server/modules/restaurants/repository/RestaurantRepository.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/repository/RestaurantRepository.java
@@ -4,12 +4,13 @@ import com.foodify.server.modules.identity.domain.Admin;
 import com.foodify.server.modules.restaurants.domain.Restaurant;
 import com.foodify.server.modules.identity.domain.RestaurantAdmin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long>, JpaSpecificationExecutor<Restaurant> {
     @Query(value = """
 
             SELECT * FROM (

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,12 @@ google:
   maps:
     api:
       key: AIzaSyDLnMZhFNGZvImKZCCMXv6Qz7sTzPyLvfY
+
+logging:
+  level:
+    root: info
+    org:
+      apache:
+        kafka: ERROR
+      springframework:
+        kafka: ERROR


### PR DESCRIPTION
## Summary
- add a public client endpoint for searching restaurants with filters, sorting, and pagination support
- implement a dedicated search service, DTOs, and repository specification support to power the query
- extend the restaurant model with delivery and promotion metadata consumed by the new API and details response

## Testing
- ./gradlew test *(fails: toolchain download disabled for Java 17)*

------
https://chatgpt.com/codex/tasks/task_b_68e26b89e64c832c8622db6f685f2b66