### PR TITLE
Restrict clients to one active order and expose ongoing order API

### DIFF
--- a/src/main/java/com/foodify/server/modules/delivery/domain/Delivery.java
+++ b/src/main/java/com/foodify/server/modules/delivery/domain/Delivery.java
@@ -3,6 +3,8 @@ package com.foodify.server.modules.delivery.domain;
 import com.foodify.server.modules.identity.domain.Driver;
 import com.foodify.server.modules.orders.domain.Order;
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,7 +18,8 @@ public class Delivery {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "order_id")
+    @JoinColumn(name = "order_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Order order;
 
     @ManyToOne

--- a/src/main/java/com/foodify/server/modules/orders/api/OrderController.java
+++ b/src/main/java/com/foodify/server/modules/orders/api/OrderController.java
@@ -1,6 +1,7 @@
 package com.foodify.server.modules.orders.api;
 
 import com.foodify.server.modules.orders.application.CustomerOrderService;
+import com.foodify.server.modules.orders.dto.OrderDto;
 import com.foodify.server.modules.orders.dto.OrderRequest;
 import com.foodify.server.modules.orders.dto.response.CreateOrderResponse;
 import jakarta.validation.Valid;
@@ -9,10 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -27,5 +25,16 @@ public class OrderController {
         Long userId = Long.parseLong(auth.getPrincipal().toString());
         CreateOrderResponse response = customerOrderService.placeOrder(userId, orderRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/ongoing")
+    @PreAuthorize("hasAuthority('ROLE_CLIENT')")
+    public ResponseEntity<OrderDto> getOngoingOrder(Authentication auth) {
+        Long userId = Long.parseLong(auth.getPrincipal().toString());
+        OrderDto ongoingOrder = customerOrderService.getOngoingOrder(userId);
+        if (ongoingOrder == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(ongoingOrder);
     }
 }

--- a/src/main/java/com/foodify/server/modules/orders/domain/Order.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/Order.java
@@ -40,12 +40,12 @@ public class Order  {
     @JoinColumn(name = "saved_address_id")
     private SavedAddress savedAddress;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
-    private List<OrderItem> items;
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> items = new ArrayList<>();
 
     private LocalDateTime orderTime;
 
-    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     private Delivery delivery;
 

--- a/src/main/java/com/foodify/server/modules/orders/domain/OrderItem.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/OrderItem.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.foodify.server.modules.restaurants.domain.MenuItem;
 import com.foodify.server.modules.restaurants.domain.MenuItemExtra;
 import jakarta.persistence.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -33,6 +35,8 @@ public class OrderItem {
     private int quantity;
 
     @JsonIgnore
-    @ManyToOne
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "order_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Order order;
 }

--- a/src/main/java/com/foodify/server/modules/orders/domain/OrderStatusHistory.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/OrderStatusHistory.java
@@ -11,6 +11,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,7 +29,8 @@ public class OrderStatusHistory {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
+    @JoinColumn(name = "order_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Order order;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/foodify/server/modules/orders/repository/OrderRepository.java
+++ b/src/main/java/com/foodify/server/modules/orders/repository/OrderRepository.java
@@ -28,6 +28,19 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             "savedAddress"
     })
     Optional<Order> findDetailedById(Long id);
+    boolean existsByClient_IdAndStatusInAndArchivedAtIsNull(Long clientId, List<OrderStatus> statuses);
+    @EntityGraph(attributePaths = {
+            "client",
+            "restaurant",
+            "restaurant.admin",
+            "delivery",
+            "delivery.driver",
+            "items",
+            "items.menuItem",
+            "pendingDriver",
+            "savedAddress"
+    })
+    Optional<Order> findFirstByClient_IdAndStatusInAndArchivedAtIsNullOrderByDateDesc(Long clientId, List<OrderStatus> statuses);
     @Query("""
     SELECT o
     FROM Order o

--- a/src/main/resources/db/migration/V1__order_relations_cascade.sql
+++ b/src/main/resources/db/migration/V1__order_relations_cascade.sql
@@ -1,0 +1,32 @@
+-- Ensure order item foreign key cascades on delete
+ALTER TABLE order_item
+    DROP CONSTRAINT IF EXISTS fkt4dc2r9nbvbujrljv3e23iibt;
+ALTER TABLE order_item
+    DROP CONSTRAINT IF EXISTS order_item_order_id_fkey;
+ALTER TABLE order_item
+    ADD CONSTRAINT fk_order_item_order
+        FOREIGN KEY (order_id)
+            REFERENCES orders(id)
+            ON DELETE CASCADE;
+
+-- Ensure delivery foreign key cascades on delete
+ALTER TABLE delivery
+    DROP CONSTRAINT IF EXISTS fk6r671c5p1g4f0r2kf1v0f7d4l;
+ALTER TABLE delivery
+    DROP CONSTRAINT IF EXISTS delivery_order_id_fkey;
+ALTER TABLE delivery
+    ADD CONSTRAINT fk_delivery_order
+        FOREIGN KEY (order_id)
+            REFERENCES orders(id)
+            ON DELETE CASCADE;
+
+-- Ensure order status history foreign key cascades on delete
+ALTER TABLE order_status_history
+    DROP CONSTRAINT IF EXISTS fk2inkbwoey17kd75dbf8e7ihg0;
+ALTER TABLE order_status_history
+    DROP CONSTRAINT IF EXISTS order_status_history_order_id_fkey;
+ALTER TABLE order_status_history
+    ADD CONSTRAINT fk_order_status_history_order
+        FOREIGN KEY (order_id)
+            REFERENCES orders(id)
+            ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- block clients from creating new orders when they already have one in progress
- add repository helpers and service method to surface a client's current order
- expose a GET /api/orders/ongoing endpoint for the frontend to fetch the active order details

## Testing
- ./gradlew test *(fails: Java 17 toolchain not configured in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e29f091cd4832caded04627008ab75