### PR TITLE
Return ongoing client order as notification DTO

### DIFF
--- a/src/main/java/com/foodify/server/modules/orders/api/OrderController.java
+++ b/src/main/java/com/foodify/server/modules/orders/api/OrderController.java
@@ -1,8 +1,8 @@
 package com.foodify.server.modules.orders.api;
 
 import com.foodify.server.modules.orders.application.CustomerOrderService;
-import com.foodify.server.modules.orders.dto.OrderDto;
 import com.foodify.server.modules.orders.dto.OrderRequest;
+import com.foodify.server.modules.orders.dto.OrderNotificationDTO;
 import com.foodify.server.modules.orders.dto.response.CreateOrderResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +29,9 @@ public class OrderController {
 
     @GetMapping("/ongoing")
     @PreAuthorize("hasAuthority('ROLE_CLIENT')")
-    public ResponseEntity<OrderDto> getOngoingOrder(Authentication auth) {
+    public ResponseEntity<OrderNotificationDTO> getOngoingOrder(Authentication auth) {
         Long userId = Long.parseLong(auth.getPrincipal().toString());
-        OrderDto ongoingOrder = customerOrderService.getOngoingOrder(userId);
+        OrderNotificationDTO ongoingOrder = customerOrderService.getOngoingOrder(userId);
         if (ongoingOrder == null) {
             return ResponseEntity.noContent().build();
         }

--- a/src/main/java/com/foodify/server/modules/orders/application/CustomerOrderService.java
+++ b/src/main/java/com/foodify/server/modules/orders/application/CustomerOrderService.java
@@ -10,11 +10,11 @@ import com.foodify.server.modules.orders.domain.OrderStatus;
 import com.foodify.server.modules.orders.dto.LocationDto;
 import com.foodify.server.modules.orders.dto.OrderItemRequest;
 import com.foodify.server.modules.orders.dto.OrderRequest;
-import com.foodify.server.modules.orders.dto.OrderDto;
+import com.foodify.server.modules.orders.dto.OrderNotificationDTO;
 import com.foodify.server.modules.orders.dto.OrderWorkflowStepDto;
 import com.foodify.server.modules.orders.dto.SavedAddressSummaryDto;
 import com.foodify.server.modules.orders.dto.response.CreateOrderResponse;
-import com.foodify.server.modules.orders.mapper.OrderMapper;
+import com.foodify.server.modules.orders.mapper.OrderNotificationMapper;
 import com.foodify.server.modules.orders.mapper.SavedAddressSummaryMapper;
 import com.foodify.server.modules.orders.repository.OrderRepository;
 import com.foodify.server.modules.restaurants.domain.MenuItem;
@@ -93,6 +93,7 @@ public class CustomerOrderService {
     private final MenuItemExtraRepository menuItemExtraRepository;
     private final OrderLifecycleService orderLifecycleService;
     private final SavedAddressRepository savedAddressRepository;
+    private final OrderNotificationMapper orderNotificationMapper;
 
     @Transactional
     public CreateOrderResponse placeOrder(Long clientId, OrderRequest request) {
@@ -198,14 +199,14 @@ public class CustomerOrderService {
     }
 
     @Transactional
-    public OrderDto getOngoingOrder(Long clientId) {
+    public OrderNotificationDTO getOngoingOrder(Long clientId) {
         if (clientId == null) {
             throw new IllegalArgumentException("Client id is required");
         }
 
         return orderRepository
                 .findFirstByClient_IdAndStatusInAndArchivedAtIsNullOrderByDateDesc(clientId, ONGOING_STATUSES)
-                .map(OrderMapper::toDto)
+                .map(orderNotificationMapper::toDto)
                 .orElse(null);
     }
 


### PR DESCRIPTION
## Summary
- update the client ongoing order endpoint to return OrderNotificationDTO payloads
- map ongoing orders through OrderNotificationMapper in CustomerOrderService so notifications include full delivery details

## Testing
- ./gradlew test *(fails: Java toolchain 17 not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e2dd0c31a8832cbbbab100d0c98c9c