### PR TITLE
Tighten catalog snapshot synchronization and availability checks

### DIFF
--- a/src/main/java/com/foodify/server/ServerApplication.java
+++ b/src/main/java/com/foodify/server/ServerApplication.java
@@ -1,13 +1,16 @@
 package com.foodify.server;
 
+import com.foodify.server.modules.restaurants.sync.CatalogCdcProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableKafka
 @EnableScheduling
+@EnableConfigurationProperties(CatalogCdcProperties.class)
 public class ServerApplication {
 
         public static void main(String[] args) {

--- a/src/main/java/com/foodify/server/modules/delivery/application/DriverService.java
+++ b/src/main/java/com/foodify/server/modules/delivery/application/DriverService.java
@@ -61,18 +61,23 @@ public class DriverService {
         delivery.setOrder(order);
         delivery.setDriver(driver);
         Point lastPosition = driverLocationService.getLastKnownPosition(driverId);
+        Double restaurantLat = order.getRestaurant() != null ? order.getRestaurant().getLatitude() : null;
+        Double restaurantLng = order.getRestaurant() != null ? order.getRestaurant().getLongitude() : null;
+        if (restaurantLat == null || restaurantLng == null) {
+            throw new IllegalStateException("Order is missing restaurant location details");
+        }
         delivery.setTimeToPickUp(
                 googleMapsService.getDrivingRoute(
                         lastPosition.getY(),
                         lastPosition.getX(),
-                        order.getRestaurant().getLatitude(),
-                        order.getRestaurant().getLongitude()
+                        restaurantLat,
+                        restaurantLng
                 )
         );
         delivery.setDeliveryTime(
                 googleMapsService.getDrivingRoute(
-                        order.getRestaurant().getLatitude(),
-                        order.getRestaurant().getLongitude(),
+                        restaurantLat,
+                        restaurantLng,
                         order.getLat(),
                         order.getLng()
                 )

--- a/src/main/java/com/foodify/server/modules/orders/application/OrderLifecycleEventListener.java
+++ b/src/main/java/com/foodify/server/modules/orders/application/OrderLifecycleEventListener.java
@@ -50,11 +50,11 @@ public class OrderLifecycleEventListener {
     }
 
     private void notifyRestaurant(Order order) {
-        if (order.getRestaurant() == null || order.getRestaurant().getAdmin() == null) {
+        if (order.getRestaurant() == null || order.getRestaurant().getAdminId() == null) {
             return;
         }
         messagingTemplate.convertAndSend(
-                "/topic/orders/" + order.getRestaurant().getAdmin().getId(),
+                "/topic/orders/" + order.getRestaurant().getAdminId(),
                 orderNotificationMapper.toDto(order)
         );
     }

--- a/src/main/java/com/foodify/server/modules/orders/domain/Order.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/Order.java
@@ -1,12 +1,11 @@
 package com.foodify.server.modules.orders.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.foodify.server.modules.addresses.domain.SavedAddress;
 import com.foodify.server.modules.delivery.domain.Delivery;
 import com.foodify.server.modules.identity.domain.Client;
 import com.foodify.server.modules.identity.domain.Driver;
-import com.foodify.server.modules.restaurants.domain.Restaurant;
+import com.foodify.server.modules.orders.domain.catalog.OrderRestaurantSnapshot;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,9 +24,8 @@ public class Order  {
     @ManyToOne
     private Client client;
 
-    @JsonIgnoreProperties({"orders", "admin", "menu"})
-    @ManyToOne
-    private Restaurant restaurant;
+    @Embedded
+    private OrderRestaurantSnapshot restaurant;
 
     private String deliveryAddress;
 

--- a/src/main/java/com/foodify/server/modules/orders/domain/OrderItem.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/OrderItem.java
@@ -1,14 +1,15 @@
 package com.foodify.server.modules.orders.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.foodify.server.modules.restaurants.domain.MenuItem;
-import com.foodify.server.modules.restaurants.domain.MenuItemExtra;
+import com.foodify.server.modules.orders.domain.catalog.OrderItemCatalogSnapshot;
+import com.foodify.server.modules.orders.domain.catalog.OrderItemExtraSnapshot;
 import jakarta.persistence.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -20,17 +21,15 @@ public class OrderItem {
 
     private String specialInstructions;
 
-    @ManyToOne
-    private MenuItem menuItem;
+    @Embedded
+    private OrderItemCatalogSnapshot catalogItem;
 
-
-    @ManyToMany
-    @JoinTable(
-            name = "order_item_menu_item_extras",
-            joinColumns = @JoinColumn(name = "order_item_id"),
-            inverseJoinColumns = @JoinColumn(name = "menu_item_extras_id")
+    @ElementCollection
+    @CollectionTable(
+            name = "order_item_extras",
+            joinColumns = @JoinColumn(name = "order_item_id")
     )
-    private List<MenuItemExtra> menuItemExtras;
+    private List<OrderItemExtraSnapshot> menuItemExtras = new ArrayList<>();
 
     private int quantity;
 

--- a/src/main/java/com/foodify/server/modules/orders/domain/catalog/OrderItemCatalogSnapshot.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/catalog/OrderItemCatalogSnapshot.java
@@ -1,0 +1,23 @@
+package com.foodify.server.modules.orders.domain.catalog;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemCatalogSnapshot {
+
+    private Long menuItemId;
+    private String menuItemName;
+    private Double basePrice;
+    private Boolean promotionActive;
+    private Double promotionPrice;
+}

--- a/src/main/java/com/foodify/server/modules/orders/domain/catalog/OrderItemExtraSnapshot.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/catalog/OrderItemExtraSnapshot.java
@@ -1,0 +1,23 @@
+package com.foodify.server.modules.orders.domain.catalog;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemExtraSnapshot {
+
+    @Column(name = "extra_id")
+    private Long extraId;
+    private String name;
+    private Double price;
+}

--- a/src/main/java/com/foodify/server/modules/orders/domain/catalog/OrderRestaurantSnapshot.java
+++ b/src/main/java/com/foodify/server/modules/orders/domain/catalog/OrderRestaurantSnapshot.java
@@ -1,0 +1,26 @@
+package com.foodify.server.modules.orders.domain.catalog;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRestaurantSnapshot {
+
+    private Long id;
+    private Long adminId;
+    private String name;
+    private String address;
+    private String phone;
+    private String imageUrl;
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/foodify/server/modules/orders/mapper/OrderNotificationMapper.java
+++ b/src/main/java/com/foodify/server/modules/orders/mapper/OrderNotificationMapper.java
@@ -9,9 +9,9 @@ import com.foodify.server.modules.orders.dto.LocationDto;
 import com.foodify.server.modules.orders.dto.OrderItemDTO;
 import com.foodify.server.modules.orders.dto.OrderNotificationDTO;
 import com.foodify.server.modules.orders.domain.OrderStatusHistory;
+import com.foodify.server.modules.orders.domain.catalog.OrderItemExtraSnapshot;
+import com.foodify.server.modules.orders.domain.catalog.OrderRestaurantSnapshot;
 import com.foodify.server.modules.orders.repository.OrderStatusHistoryRepository;
-import com.foodify.server.modules.restaurants.domain.MenuItemExtra;
-import com.foodify.server.modules.restaurants.domain.Restaurant;
 import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
@@ -36,10 +36,10 @@ public class OrderNotificationMapper {
         OrderNotificationDTO.DeliverySummary deliverySummary = toDeliverySummary(order.getDelivery());
 
         List<OrderItemDTO> items = order.getItems() == null ? List.of() : order.getItems().stream().map(item -> new OrderItemDTO(
-                item.getMenuItem().getId(),
-                item.getMenuItem().getName(),
+                item.getCatalogItem() != null ? item.getCatalogItem().getMenuItemId() : null,
+                item.getCatalogItem() != null ? item.getCatalogItem().getMenuItemName() : null,
                 item.getQuantity(),
-                item.getMenuItemExtras().stream().map(MenuItemExtra::getName).toList(),
+                item.getMenuItemExtras().stream().map(OrderItemExtraSnapshot::getName).toList(),
                 item.getSpecialInstructions()
         )).toList();
 
@@ -76,14 +76,14 @@ public class OrderNotificationMapper {
         return new LocationDto(lat, lng);
     }
 
-    private OrderNotificationDTO.RestaurantSummary toRestaurantSummary(Restaurant restaurant) {
+    private OrderNotificationDTO.RestaurantSummary toRestaurantSummary(OrderRestaurantSnapshot restaurant) {
         if (restaurant == null) {
             return null;
         }
         LocationDto location = null;
-        double latitude = restaurant.getLatitude();
-        double longitude = restaurant.getLongitude();
-        if (!(latitude == 0.0 && longitude == 0.0)) {
+        Double latitude = restaurant.getLatitude();
+        Double longitude = restaurant.getLongitude();
+        if (latitude != null && longitude != null && !(latitude == 0.0 && longitude == 0.0)) {
             location = new LocationDto(latitude, longitude);
         }
         return new OrderNotificationDTO.RestaurantSummary(

--- a/src/main/java/com/foodify/server/modules/orders/repository/OrderRepository.java
+++ b/src/main/java/com/foodify/server/modules/orders/repository/OrderRepository.java
@@ -3,7 +3,6 @@ package com.foodify.server.modules.orders.repository;
 import com.foodify.server.modules.orders.domain.OrderStatus;
 import com.foodify.server.modules.identity.domain.Client;
 import com.foodify.server.modules.orders.domain.Order;
-import com.foodify.server.modules.restaurants.domain.Restaurant;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,17 +12,14 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-    List<Order> findAllByRestaurantOrderByDateDesc(Restaurant restaurant);
+    List<Order> findAllByRestaurant_IdOrderByDateDesc(Long restaurantId);
     List<Order> findAllByClientOrderByDateDesc(Client client);
     List<Order> findAllByPendingDriverId(Long pendingDriverId);
     @EntityGraph(attributePaths = {
             "client",
-            "restaurant",
-            "restaurant.admin",
             "delivery",
             "delivery.driver",
             "items",
-            "items.menuItem",
             "pendingDriver",
             "savedAddress"
     })
@@ -31,12 +27,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     boolean existsByClient_IdAndStatusInAndArchivedAtIsNull(Long clientId, List<OrderStatus> statuses);
     @EntityGraph(attributePaths = {
             "client",
-            "restaurant",
-            "restaurant.admin",
             "delivery",
             "delivery.driver",
             "items",
-            "items.menuItem",
             "pendingDriver",
             "savedAddress"
     })

--- a/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogCdcListener.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogCdcListener.java
@@ -1,0 +1,100 @@
+package com.foodify.server.modules.restaurants.sync;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CatalogCdcListener {
+
+    private final ObjectMapper objectMapper;
+    private final CatalogSnapshotCache snapshotCache;
+
+    @KafkaListener(topics = "#{catalogCdcProperties.menuItemTopic}")
+    public void onMenuItemChange(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            CatalogMenuItemSnapshot snapshot = new CatalogMenuItemSnapshot(
+                    asLong(root, "id"),
+                    asLong(root, "restaurantId"),
+                    asDouble(root, "price"),
+                    asDoubleObject(root, "promotionPrice"),
+                    asBoolean(root, "promotionActive"),
+                    asBoolean(root, "available")
+            );
+            snapshotCache.putMenuItem(snapshot);
+            log.debug("Catalog CDC synced menu item {}", snapshot.id());
+        } catch (Exception ex) {
+            log.warn("Failed to process menu item CDC payload: {}", message, ex);
+        }
+    }
+
+    @KafkaListener(topics = "#{catalogCdcProperties.menuItemExtraTopic}")
+    public void onMenuItemExtraChange(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            CatalogMenuItemExtraSnapshot snapshot = new CatalogMenuItemExtraSnapshot(
+                    asLong(root, "id"),
+                    asLong(root, "menuItemId"),
+                    asText(root, "name"),
+                    asDoubleObject(root, "price"),
+                    asBoolean(root, "available")
+            );
+            snapshotCache.putExtra(snapshot);
+            log.debug("Catalog CDC synced extra {}", snapshot.id());
+        } catch (Exception ex) {
+            log.warn("Failed to process menu item extra CDC payload: {}", message, ex);
+        }
+    }
+
+    @KafkaListener(topics = "#{catalogCdcProperties.restaurantTopic}")
+    public void onRestaurantChange(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            CatalogRestaurantSnapshot snapshot = new CatalogRestaurantSnapshot(
+                    asLong(root, "id"),
+                    asLong(root, "adminId"),
+                    asText(root, "name"),
+                    asText(root, "address"),
+                    asText(root, "phone"),
+                    asText(root, "imageUrl"),
+                    asDoubleObject(root, "latitude"),
+                    asDoubleObject(root, "longitude")
+            );
+            snapshotCache.putRestaurant(snapshot);
+            log.debug("Catalog CDC synced restaurant {}", snapshot.id());
+        } catch (Exception ex) {
+            log.warn("Failed to process restaurant CDC payload: {}", message, ex);
+        }
+    }
+
+    private Long asLong(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asLong() : null;
+    }
+
+    private Double asDouble(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asDouble() : 0.0;
+    }
+
+    private Double asDoubleObject(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asDouble() : null;
+    }
+
+    private Boolean asBoolean(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asBoolean() : null;
+    }
+
+    private String asText(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asText() : null;
+    }
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogCdcProperties.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogCdcProperties.java
@@ -1,0 +1,23 @@
+package com.foodify.server.modules.restaurants.sync;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "catalog.cdc")
+public class CatalogCdcProperties {
+
+    @NotBlank
+    private String menuItemTopic = "catalog-service.catalog.menu_items";
+
+    @NotBlank
+    private String menuItemExtraTopic = "catalog-service.catalog.menu_item_extras";
+
+    @NotBlank
+    private String restaurantTopic = "catalog-service.catalog.restaurants";
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogMenuItemExtraSnapshot.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogMenuItemExtraSnapshot.java
@@ -1,0 +1,10 @@
+package com.foodify.server.modules.restaurants.sync;
+
+public record CatalogMenuItemExtraSnapshot(
+        Long id,
+        Long menuItemId,
+        String name,
+        Double price,
+        Boolean available
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogMenuItemSnapshot.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogMenuItemSnapshot.java
@@ -1,0 +1,11 @@
+package com.foodify.server.modules.restaurants.sync;
+
+public record CatalogMenuItemSnapshot(
+        Long id,
+        Long restaurantId,
+        Double price,
+        Double promotionPrice,
+        Boolean promotionActive,
+        Boolean available
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogRestaurantSnapshot.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogRestaurantSnapshot.java
@@ -1,0 +1,13 @@
+package com.foodify.server.modules.restaurants.sync;
+
+public record CatalogRestaurantSnapshot(
+        Long id,
+        Long adminId,
+        String name,
+        String address,
+        String phone,
+        String imageUrl,
+        Double latitude,
+        Double longitude
+) {
+}

--- a/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogSnapshotCache.java
+++ b/src/main/java/com/foodify/server/modules/restaurants/sync/CatalogSnapshotCache.java
@@ -1,0 +1,57 @@
+package com.foodify.server.modules.restaurants.sync;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class CatalogSnapshotCache {
+
+    private final ConcurrentMap<Long, CatalogMenuItemSnapshot> menuItems = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CatalogMenuItemExtraSnapshot> extras = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CatalogRestaurantSnapshot> restaurants = new ConcurrentHashMap<>();
+
+    public void putMenuItem(CatalogMenuItemSnapshot snapshot) {
+        if (snapshot == null || snapshot.id() == null) {
+            return;
+        }
+        menuItems.put(snapshot.id(), snapshot);
+    }
+
+    public Optional<CatalogMenuItemSnapshot> getMenuItem(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(menuItems.get(id));
+    }
+
+    public void putExtra(CatalogMenuItemExtraSnapshot snapshot) {
+        if (snapshot == null || snapshot.id() == null) {
+            return;
+        }
+        extras.put(snapshot.id(), snapshot);
+    }
+
+    public Optional<CatalogMenuItemExtraSnapshot> getExtra(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(extras.get(id));
+    }
+
+    public void putRestaurant(CatalogRestaurantSnapshot snapshot) {
+        if (snapshot == null || snapshot.id() == null) {
+            return;
+        }
+        restaurants.put(snapshot.id(), snapshot);
+    }
+
+    public Optional<CatalogRestaurantSnapshot> getRestaurant(Long id) {
+        if (id == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(restaurants.get(id));
+    }
+}

--- a/src/test/java/com/foodify/server/modules/orders/application/CustomerOrderServicePricingConsistencyTest.java
+++ b/src/test/java/com/foodify/server/modules/orders/application/CustomerOrderServicePricingConsistencyTest.java
@@ -1,0 +1,331 @@
+package com.foodify.server.modules.orders.application;
+
+import com.foodify.server.modules.addresses.application.SavedAddressDirectoryService;
+import com.foodify.server.modules.identity.application.ClientDirectoryService;
+import com.foodify.server.modules.identity.domain.AuthProvider;
+import com.foodify.server.modules.identity.domain.Client;
+import com.foodify.server.modules.identity.domain.RestaurantAdmin;
+import com.foodify.server.modules.identity.domain.Role;
+import com.foodify.server.modules.orders.domain.Order;
+import com.foodify.server.modules.orders.dto.LocationDto;
+import com.foodify.server.modules.orders.dto.OrderItemRequest;
+import com.foodify.server.modules.orders.dto.OrderRequest;
+import com.foodify.server.modules.orders.dto.response.CreateOrderResponse;
+import com.foodify.server.modules.orders.mapper.OrderNotificationMapper;
+import com.foodify.server.modules.orders.repository.OrderRepository;
+import com.foodify.server.modules.restaurants.application.RestaurantCatalogService;
+import com.foodify.server.modules.restaurants.domain.MenuItem;
+import com.foodify.server.modules.restaurants.domain.MenuItemExtra;
+import com.foodify.server.modules.restaurants.domain.MenuOptionGroup;
+import com.foodify.server.modules.restaurants.domain.Restaurant;
+import com.foodify.server.modules.restaurants.sync.CatalogMenuItemExtraSnapshot;
+import com.foodify.server.modules.restaurants.sync.CatalogMenuItemSnapshot;
+import com.foodify.server.modules.restaurants.sync.CatalogRestaurantSnapshot;
+import com.foodify.server.modules.restaurants.sync.CatalogSnapshotCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerOrderServicePricingConsistencyTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private ClientDirectoryService clientDirectoryService;
+    @Mock
+    private RestaurantCatalogService restaurantCatalogService;
+    @Mock
+    private OrderLifecycleService orderLifecycleService;
+    @Mock
+    private SavedAddressDirectoryService savedAddressDirectoryService;
+    @Mock
+    private OrderNotificationMapper orderNotificationMapper;
+
+    private CatalogSnapshotCache catalogSnapshotCache;
+
+    private CustomerOrderService customerOrderService;
+
+    @BeforeEach
+    void setUp() {
+        catalogSnapshotCache = new CatalogSnapshotCache();
+        customerOrderService = new CustomerOrderService(
+                orderRepository,
+                clientDirectoryService,
+                restaurantCatalogService,
+                orderLifecycleService,
+                savedAddressDirectoryService,
+                orderNotificationMapper,
+                catalogSnapshotCache
+        );
+    }
+
+    @Test
+    void appliesCatalogPricingSnapshotsWhenPromotionsOrExtrasChange() {
+        Long clientId = 15L;
+        Long restaurantId = 30L;
+        Long menuItemId = 50L;
+        Long extraId = 70L;
+
+        Client client = new Client();
+        client.setId(clientId);
+        client.setEmail("client@example.com");
+        client.setPassword("secret");
+        client.setAuthProvider(AuthProvider.LOCAL);
+        client.setRole(Role.CLIENT);
+        when(clientDirectoryService.getClientOrThrow(clientId)).thenReturn(client);
+
+        when(orderRepository.existsByClient_IdAndStatusInAndArchivedAtIsNull(eq(clientId), anyList())).thenReturn(false);
+
+        RestaurantAdmin admin = new RestaurantAdmin();
+        admin.setId(200L);
+        admin.setEmail("admin@example.com");
+        admin.setPassword("pw");
+        admin.setAuthProvider(AuthProvider.LOCAL);
+        admin.setRole(Role.RESTAURANT_ADMIN);
+
+        Restaurant restaurant = new Restaurant();
+        restaurant.setId(restaurantId);
+        restaurant.setName("Tasty Meals");
+        restaurant.setLatitude(12.3);
+        restaurant.setLongitude(-45.6);
+        restaurant.setAdmin(admin);
+        when(restaurantCatalogService.getRestaurantOrThrow(restaurantId)).thenReturn(restaurant);
+
+        MenuItem menuItem = new MenuItem();
+        menuItem.setId(menuItemId);
+        menuItem.setName("Pasta");
+        menuItem.setPrice(9.0);
+        menuItem.setPromotionActive(false);
+        menuItem.setRestaurant(restaurant);
+        when(restaurantCatalogService.getMenuItemOrThrow(menuItemId)).thenReturn(menuItem);
+
+        MenuOptionGroup optionGroup = new MenuOptionGroup();
+        optionGroup.setMenuItem(menuItem);
+
+        MenuItemExtra extra = new MenuItemExtra();
+        extra.setId(extraId);
+        extra.setName("Cheese");
+        extra.setPrice(1.0);
+        extra.setOptionGroup(optionGroup);
+        when(restaurantCatalogService.getMenuItemExtras(List.of(extraId))).thenReturn(List.of(extra));
+
+        catalogSnapshotCache.putMenuItem(new CatalogMenuItemSnapshot(menuItemId, restaurantId, 9.0, 7.0, true, true));
+        catalogSnapshotCache.putExtra(new CatalogMenuItemExtraSnapshot(extraId, menuItemId, "Cheese", 3.0, true));
+
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            order.setId(999L);
+            order.setDate(LocalDateTime.now());
+            return order;
+        });
+        doNothing().when(orderLifecycleService).registerCreation(any(Order.class), eq("client:" + clientId));
+
+        OrderRequest request = new OrderRequest();
+        request.setDeliveryAddress("123 Main");
+        request.setLocation(new LocationDto(10.0, 20.0));
+        request.setPaymentMethod("CARD");
+        request.setRestaurantId(restaurantId);
+        request.setItems(List.of(new OrderItemRequest() {{
+            setMenuItemId(menuItemId);
+            setQuantity(1);
+            setExtraIds(List.of(extraId));
+        }}));
+
+        CreateOrderResponse response = customerOrderService.placeOrder(clientId, request);
+
+        assertThat(response.payment().subtotal()).isEqualByComparingTo(BigDecimal.valueOf(7.0));
+        assertThat(response.payment().extrasTotal()).isEqualByComparingTo(BigDecimal.valueOf(3.0));
+        assertThat(response.payment().total()).isEqualByComparingTo(BigDecimal.valueOf(10.0));
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).unitPrice()).isEqualByComparingTo(BigDecimal.valueOf(7.0));
+        assertThat(response.items().get(0).extras()).hasSize(1);
+        assertThat(response.items().get(0).extras().get(0).price()).isEqualByComparingTo(BigDecimal.valueOf(3.0));
+        assertThat(response.items().get(0).extras().get(0).id()).isEqualTo(extraId);
+
+        ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(orderCaptor.capture());
+        Order persisted = orderCaptor.getValue();
+        assertThat(persisted.getItems()).hasSize(1);
+        assertThat(persisted.getItems().get(0).getCatalogItem().getPromotionActive()).isTrue();
+        assertThat(persisted.getItems().get(0).getCatalogItem().getPromotionPrice()).isEqualTo(7.0);
+        assertThat(persisted.getItems().get(0).getMenuItemExtras().get(0).getPrice()).isEqualTo(3.0);
+    }
+
+    @Test
+    void throwsWhenCatalogReportsMenuItemUnavailable() {
+        Long clientId = 5L;
+        Long restaurantId = 7L;
+        Long menuItemId = 9L;
+
+        Client client = new Client();
+        client.setId(clientId);
+        when(clientDirectoryService.getClientOrThrow(clientId)).thenReturn(client);
+        when(orderRepository.existsByClient_IdAndStatusInAndArchivedAtIsNull(eq(clientId), anyList())).thenReturn(false);
+
+        Restaurant restaurant = new Restaurant();
+        restaurant.setId(restaurantId);
+        when(restaurantCatalogService.getRestaurantOrThrow(restaurantId)).thenReturn(restaurant);
+
+        MenuItem menuItem = new MenuItem();
+        menuItem.setId(menuItemId);
+        menuItem.setRestaurant(restaurant);
+        when(restaurantCatalogService.getMenuItemOrThrow(menuItemId)).thenReturn(menuItem);
+
+        catalogSnapshotCache.putMenuItem(new CatalogMenuItemSnapshot(menuItemId, restaurantId, 10.0, null, null, false));
+
+        OrderRequest request = new OrderRequest();
+        request.setRestaurantId(restaurantId);
+        request.setPaymentMethod("CARD");
+        request.setDeliveryAddress("123 St");
+        request.setItems(List.of(new OrderItemRequest() {{
+            setMenuItemId(menuItemId);
+            setQuantity(1);
+        }}));
+
+        assertThatThrownBy(() -> customerOrderService.placeOrder(clientId, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void throwsWhenCatalogReportsExtraUnavailable() {
+        Long clientId = 11L;
+        Long restaurantId = 22L;
+        Long menuItemId = 33L;
+        Long extraId = 44L;
+
+        Client client = new Client();
+        client.setId(clientId);
+        when(clientDirectoryService.getClientOrThrow(clientId)).thenReturn(client);
+        when(orderRepository.existsByClient_IdAndStatusInAndArchivedAtIsNull(eq(clientId), anyList())).thenReturn(false);
+
+        Restaurant restaurant = new Restaurant();
+        restaurant.setId(restaurantId);
+        when(restaurantCatalogService.getRestaurantOrThrow(restaurantId)).thenReturn(restaurant);
+
+        MenuItem menuItem = new MenuItem();
+        menuItem.setId(menuItemId);
+        menuItem.setRestaurant(restaurant);
+        when(restaurantCatalogService.getMenuItemOrThrow(menuItemId)).thenReturn(menuItem);
+
+        MenuOptionGroup optionGroup = new MenuOptionGroup();
+        optionGroup.setMenuItem(menuItem);
+
+        MenuItemExtra extra = new MenuItemExtra();
+        extra.setId(extraId);
+        extra.setOptionGroup(optionGroup);
+        when(restaurantCatalogService.getMenuItemExtras(List.of(extraId))).thenReturn(List.of(extra));
+
+        catalogSnapshotCache.putMenuItem(new CatalogMenuItemSnapshot(menuItemId, restaurantId, 10.0, null, null, true));
+        catalogSnapshotCache.putExtra(new CatalogMenuItemExtraSnapshot(extraId, menuItemId, "Sauce", 1.5, false));
+
+        OrderRequest request = new OrderRequest();
+        request.setRestaurantId(restaurantId);
+        request.setPaymentMethod("CARD");
+        request.setDeliveryAddress("123 St");
+        request.setItems(List.of(new OrderItemRequest() {{
+            setMenuItemId(menuItemId);
+            setQuantity(1);
+            setExtraIds(List.of(extraId));
+        }}));
+
+        assertThatThrownBy(() -> customerOrderService.placeOrder(clientId, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(ex -> assertThat(((ResponseStatusException) ex).getStatusCode().value())
+                        .isEqualTo(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    @Test
+    void overlaysRestaurantSnapshotFromCatalogCache() {
+        Long clientId = 60L;
+        Long restaurantId = 61L;
+        Long menuItemId = 62L;
+
+        Client client = new Client();
+        client.setId(clientId);
+        when(clientDirectoryService.getClientOrThrow(clientId)).thenReturn(client);
+        when(orderRepository.existsByClient_IdAndStatusInAndArchivedAtIsNull(eq(clientId), anyList())).thenReturn(false);
+
+        Restaurant restaurant = new Restaurant();
+        restaurant.setId(restaurantId);
+        restaurant.setName("Local Name");
+        restaurant.setAddress("Local Address");
+        restaurant.setPhone("111-222");
+        restaurant.setImageUrl("local.png");
+        restaurant.setLatitude(1.0);
+        restaurant.setLongitude(2.0);
+        when(restaurantCatalogService.getRestaurantOrThrow(restaurantId)).thenReturn(restaurant);
+
+        MenuItem menuItem = new MenuItem();
+        menuItem.setId(menuItemId);
+        menuItem.setRestaurant(restaurant);
+        menuItem.setName("Burger");
+        menuItem.setPrice(12.0);
+        when(restaurantCatalogService.getMenuItemOrThrow(menuItemId)).thenReturn(menuItem);
+
+        catalogSnapshotCache.putRestaurant(new CatalogRestaurantSnapshot(
+                restaurantId,
+                999L,
+                "Remote Name",
+                "Remote Address",
+                "555-999",
+                "remote.png",
+                3.3,
+                4.4
+        ));
+        catalogSnapshotCache.putMenuItem(new CatalogMenuItemSnapshot(menuItemId, restaurantId, 14.0, null, null, true));
+
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            order.setId(321L);
+            order.setDate(LocalDateTime.now());
+            return order;
+        });
+        doNothing().when(orderLifecycleService).registerCreation(any(Order.class), any());
+
+        OrderRequest request = new OrderRequest();
+        request.setRestaurantId(restaurantId);
+        request.setPaymentMethod("CARD");
+        request.setDeliveryAddress("123 St");
+        request.setItems(List.of(new OrderItemRequest() {{
+            setMenuItemId(menuItemId);
+            setQuantity(1);
+        }}));
+
+        CreateOrderResponse response = customerOrderService.placeOrder(clientId, request);
+
+        assertThat(response.restaurant().name()).isEqualTo("Remote Name");
+
+        ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(orderCaptor.capture());
+        Order persisted = orderCaptor.getValue();
+        assertThat(persisted.getRestaurant().getName()).isEqualTo("Remote Name");
+        assertThat(persisted.getRestaurant().getAddress()).isEqualTo("Remote Address");
+        assertThat(persisted.getRestaurant().getPhone()).isEqualTo("555-999");
+        assertThat(persisted.getRestaurant().getImageUrl()).isEqualTo("remote.png");
+        assertThat(persisted.getRestaurant().getLatitude()).isEqualTo(3.3);
+        assertThat(persisted.getRestaurant().getLongitude()).isEqualTo(4.4);
+        assertThat(persisted.getRestaurant().getAdminId()).isEqualTo(999L);
+    }
+}

--- a/src/test/java/com/foodify/server/modules/restaurants/application/RestaurantSearchServiceIntegrationTest.java
+++ b/src/test/java/com/foodify/server/modules/restaurants/application/RestaurantSearchServiceIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.foodify.server.modules.restaurants.application;
+
+import com.foodify.server.modules.restaurants.domain.MenuItem;
+import com.foodify.server.modules.restaurants.domain.Restaurant;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchItemDto;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchQuery;
+import com.foodify.server.modules.restaurants.dto.RestaurantSearchSort;
+import com.foodify.server.modules.restaurants.dto.PageResponse;
+import com.foodify.server.modules.restaurants.repository.MenuItemRepository;
+import com.foodify.server.modules.restaurants.repository.RestaurantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(RestaurantSearchService.class)
+class RestaurantSearchServiceIntegrationTest {
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    @Autowired
+    private MenuItemRepository menuItemRepository;
+
+    @Autowired
+    private RestaurantSearchService restaurantSearchService;
+
+    private Restaurant promotedRestaurant;
+
+    @BeforeEach
+    void setUp() {
+        promotedRestaurant = new Restaurant();
+        promotedRestaurant.setName("Promoted Place");
+        promotedRestaurant.setTopChoice(true);
+        promotedRestaurant.setFreeDelivery(true);
+        promotedRestaurant.setTopEat(true);
+        promotedRestaurant.setDeliveryFee(2.0);
+        promotedRestaurant.setDeliveryTimeRange("25-35 min");
+        promotedRestaurant.setRating(4.8);
+        promotedRestaurant = restaurantRepository.save(promotedRestaurant);
+
+        MenuItem promotedItem = new MenuItem();
+        promotedItem.setName("Signature Dish");
+        promotedItem.setPrice(12.0);
+        promotedItem.setPromotionActive(true);
+        promotedItem.setPromotionPrice(9.0);
+        promotedItem.setPromotionLabel("LIMITED");
+        promotedItem.setRestaurant(promotedRestaurant);
+        menuItemRepository.save(promotedItem);
+
+        Restaurant regularRestaurant = new Restaurant();
+        regularRestaurant.setName("Regular Eats");
+        regularRestaurant.setTopChoice(false);
+        regularRestaurant.setFreeDelivery(false);
+        regularRestaurant.setTopEat(false);
+        regularRestaurant.setDeliveryFee(6.0);
+        regularRestaurant.setDeliveryTimeRange("40-50 min");
+        regularRestaurant.setRating(4.2);
+        restaurantRepository.save(regularRestaurant);
+    }
+
+    @Test
+    void searchFiltersByPromotionTopChoiceAndAvailability() {
+        RestaurantSearchQuery query = new RestaurantSearchQuery(
+                null,
+                true,
+                true,
+                true,
+                RestaurantSearchSort.POPULAR,
+                true,
+                5.0,
+                1,
+                10
+        );
+
+        PageResponse<RestaurantSearchItemDto> response = restaurantSearchService.search(query);
+
+        assertThat(response.items()).hasSize(1);
+        RestaurantSearchItemDto item = response.items().get(0);
+        assertThat(item.id()).isEqualTo(promotedRestaurant.getId());
+        assertThat(item.promotedMenuItems()).hasSize(1);
+        assertThat(item.promotedMenuItems().get(0).promotionPrice()).isEqualTo(9.0);
+    }
+
+    @Test
+    void searchRespectsDeliveryFeeThreshold() {
+        RestaurantSearchQuery query = new RestaurantSearchQuery(
+                null,
+                null,
+                null,
+                null,
+                RestaurantSearchSort.PICKED,
+                null,
+                1.0,
+                1,
+                10
+        );
+
+        PageResponse<RestaurantSearchItemDto> response = restaurantSearchService.search(query);
+
+        assertThat(response.items()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- overlay remote catalog snapshots on order restaurant, item, and extra data while rejecting unavailable selections
- extend the catalog CDC listener/cache with restaurant snapshots to keep admin, contact, and location fields synchronized
- add service tests for remote availability validation and restaurant snapshot application alongside existing pricing coverage

## Testing
- `./gradlew test --console=plain` *(fails: Java toolchain download disabled in container image)*

------
https://chatgpt.com/codex/tasks/task_b_68e639615f9c832c83734f7351aafe32